### PR TITLE
Fix lap calculation and sort valid races by round

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -720,10 +720,13 @@ function generateLaps(drivers, lapsTime, tyreData) {
         };
     });
 
-
     laps.push(JSON.parse(JSON.stringify(driversWithScore)));
 
-    const realNumberOfLaps = lapsTime[Number(drivers[0].driverId)].length;
+    
+    const lapArrays = Object.values(lapsTime).filter(arr => Array.isArray(arr) && arr.length > 0);
+    const realNumberOfLaps = lapArrays.length > 0
+        ? Math.max(...lapArrays.map(arr => arr.length))
+        : 0;
 
     for (let lap = 1; lap < realNumberOfLaps; lap++) {
         const previousLap = JSON.parse(JSON.stringify(laps[lap - 1]));

--- a/src/script.js
+++ b/src/script.js
@@ -592,6 +592,8 @@ yearSelect.addEventListener("change", async () => {
     raceSelect.disabled = false;
 
     const validRaces = await getValidRacesByYear(parseInt(selectedYear));
+    
+    validRaces.sort((a, b) => new Number(a.round) - new Number(b.round));
 
     if (selectedYear && validRaces.length > 0) {
         validRaces.forEach(race => {


### PR DESCRIPTION
Adjust the calculation of the real number of laps to handle empty arrays and sort valid races by round when selecting the year.